### PR TITLE
Alter the FileCopyrightText formatting slightly to add OC's website

### DIFF
--- a/src/main/kotlin/com.opencastsoftware.gradle.java-conventions.gradle.kts
+++ b/src/main/kotlin/com.opencastsoftware.gradle.java-conventions.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-FileCopyrightText:  © 2023 Opencast Software Europe Ltd <https://opencastsoftware.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 import com.vanniktech.maven.publish.SonatypeHost
@@ -45,7 +45,7 @@ spotless {
         licenseHeader(
             """
             /*
-             * SPDX-FileCopyrightText:  Copyright ${"$"}YEAR Opencast Software Europe Ltd
+             * SPDX-FileCopyrightText:  © ${"$"}YEAR Opencast Software Europe Ltd <https://opencastsoftware.com>
              * SPDX-License-Identifier: Apache-2.0
              */
             """


### PR DESCRIPTION
Following guidance from [How and why to properly write copyright statements in your code](https://liferay.dev/blogs/-/blogs/how-and-why-to-properly-write-copyright-statements-in-your-code):

* It seems that `©` is more universally-recognised
* The OC website (as a point of contact) was not previously included