### PR TITLE
Use the Sonatype Central Portal for publishing in the Java convention plugin

### DIFF
--- a/src/main/kotlin/com.opencastsoftware.gradle.java-conventions.gradle.kts
+++ b/src/main/kotlin/com.opencastsoftware.gradle.java-conventions.gradle.kts
@@ -54,7 +54,7 @@ spotless {
         )
         removeUnusedImports()
         importOrder("", "javax|java", "\\#") // IntelliJ import order
-        indentWithSpaces()
+        leadingTabsToSpaces()
         trimTrailingWhitespace()
         endWithNewline()
     }
@@ -63,7 +63,7 @@ spotless {
         encoding("UTF-8")
         target("*.gradle.kts")
         ktfmt().kotlinlangStyle()
-        indentWithSpaces()
+        leadingTabsToSpaces()
         trimTrailingWhitespace()
         endWithNewline()
     }
@@ -71,7 +71,7 @@ spotless {
 
 mavenPublishing {
     description = project.description
-    publishToMavenCentral(SonatypeHost.S01, true)
+    publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL, true)
     signAllPublications()
     pom {
         organization {


### PR DESCRIPTION
Due to [OSSRH being shut down](https://central.sonatype.org/news/20250326_ossrh_sunset/), we need to migrate to Sonatype Central Portal.

I have migrated the `com.opencastsoftware` namespace on the Sonatype interface, and have been able to publish snapshots to the Central Portal successfully in https://github.com/opencastsoftware/gradle-convention-plugins/commit/dc681f8be59f49063211b39f0407d789a1029ecd.

This PR changes the publishing configuration in the Java convention plugin to use the Central Portal, which should switch all dependent projects over to the Central Portal once they take a new version of the plugin.